### PR TITLE
make it compile with gcc 11 and clang 12, add github action to compile with warnings for gcc and clang

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,53 @@
+name: CMake
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        cxx_compiler: [g++-11, clang++-12]
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Set up GCC
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: 11
+          platform: x64
+      - name: Set up Clang
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: 12
+          platform: x64
+
+      - name: Configure CMake
+        env:
+          CXX: ${{ matrix.cxx_compiler }}
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: cmake -B ${{github.workspace}}/build --preset=default -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }}
+
+      - name: Build
+        # Build your program with the given configuration
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest -V -C ${{env.BUILD_TYPE}}

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ bld/
 [Oo]ut/
 [Ll]og/
 [Ll]ogs/
+build*/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(
+  Tensor-plus-plus
+  VERSION 0.1.0
+  DESCRIPTION ""
+  HOMEPAGE_URL ""
+  LANGUAGES CXX)
+
+add_executable(test)
+target_sources(test PRIVATE Source.cpp)
+target_compile_features(test PRIVATE cxx_std_20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,14 @@ project(
   HOMEPAGE_URL ""
   LANGUAGES CXX)
 
-add_executable(test)
-target_sources(test PRIVATE Source.cpp)
-target_compile_features(test PRIVATE cxx_std_20)
+add_executable(main)
+target_sources(main PRIVATE Source.cpp)
+target_compile_features(main PRIVATE cxx_std_20)
+
+add_executable(all_test)
+target_sources(all_test PRIVATE all_test.cpp)
+target_compile_features(all_test PRIVATE cxx_std_20)
+
+enable_testing()
+
+add_test(NAME test_all COMMAND ${CMAKE_CURRENT_BINARY_DIR}/all_test)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build_ninja",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror=return-type -Wold-style-cast -Weffc++ -pedantic-errors -Wswitch-enum -Werror=write-strings -Wconversion -Wsign-conversion -fdiagnostics-color=always",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror=return-type -Wold-style-cast -Weffc++ -pedantic-errors -Wswitch-enum -Werror=write-strings -Wconversion -Wsign-conversion -fdiagnostics-color=always -Werror",
         "CMAKE_EXPORT_COMPILE_COMMANDS": {
           "type": "BOOL",
           "value": "TRUE"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default Config",
+      "description": "Default build using Ninja generator and gcc/clang warnings",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build_ninja",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Werror=return-type -Wold-style-cast -Weffc++ -pedantic-errors -Wswitch-enum -Werror=write-strings -Wconversion -Wsign-conversion -fdiagnostics-color=always",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {
+          "type": "BOOL",
+          "value": "TRUE"
+        }
+      }
+    }
+  ]
+}

--- a/Source.cpp
+++ b/Source.cpp
@@ -1,10 +1,11 @@
-#include <iostream>
-#include <vector>
-#include <algorithm>
 #include "tensor.hpp"
 #include "helpers.hpp"
 #include "tensor_testing_suit.hpp"
 #include "benchmark.hpp"
+
+#include <algorithm>
+#include <iostream>
+#include <vector>
 
 using namespace tensor_lib;
 

--- a/all_test.cpp
+++ b/all_test.cpp
@@ -1,0 +1,6 @@
+#include "tensor_testing_suit.hpp"
+
+int main()
+{
+  tensor_testing_suit::RUN_ALL_TESTS();
+}

--- a/benchmark.hpp
+++ b/benchmark.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "tensor.hpp"
+
+#include <chrono>
 #include <iostream>
 #include <vector>
-#include <chrono>
-#include "tensor.hpp"
 
 namespace benchmark
 {

--- a/helpers.hpp
+++ b/helpers.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <vector>
 #include "tensor.hpp"
+
+#include <vector>
 
 template<typename T, size_t Size>
 void display(const std::array<T, Size>& arr)

--- a/tensor.hpp
+++ b/tensor.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <array>
-#include <numeric>
-#include <utility>
-#include <memory>
-#include <span>
 #include "useful_concepts.hpp"
 #include "useful_specializations.hpp"
+
+#include <array>
 #include <chrono>
+#include <cstring>
+#include <memory>
+#include <numeric>
+#include <span>
+#include <utility>
 
 namespace tensor_lib
 {
@@ -137,8 +139,8 @@ namespace tensor_lib
         friend class subdimension<T, Rank>;
         friend class const_subdimension<T, Rank>;
 
-        using iterator = _tensor_common<T>::iterator;
-        using const_iterator = _tensor_common<T>::const_iterator;
+        using iterator = typename _tensor_common<T>::iterator;
+        using const_iterator = typename _tensor_common<T>::const_iterator;
 
         // All tensor() constructors take a series of unsigned, non-zero, integeres that reprezent
         // the sizes of each dimension, be it as an array or initializer_list.
@@ -152,8 +154,8 @@ namespace tensor_lib
         }
 
         template<typename... Sizes>
-            requires useful_concepts::size_of_parameter_pack_equals<Sizes..., Rank>
-            && useful_concepts::constructable_from_common_type<std::size_t, Sizes...>
+        requires useful_concepts::size_of_parameter_pack_equals<Rank, Sizes...> &&
+          useful_concepts::constructable_from_common_type<std::size_t, Sizes...>
         constexpr tensor(const Sizes ... sizes) noexcept
             : _order_of_dimension{ static_cast<std::size_t>(sizes)... }
         {
@@ -287,8 +289,8 @@ namespace tensor_lib
         }
 
         template<typename... Sizes>
-            requires useful_concepts::size_of_parameter_pack_equals<Sizes..., Rank>
-            && useful_concepts::constructable_from_common_type<std::size_t, Sizes...>
+        requires useful_concepts::size_of_parameter_pack_equals<Rank, Sizes...> &&
+          useful_concepts::constructable_from_common_type<std::size_t, Sizes...>
         constexpr void resize(const Sizes ... new_sizes) TENSORLIB_NOEXCEPT_IN_RELEASE
         {
             _order_of_dimension = { static_cast<std::size_t>(new_sizes)... };
@@ -421,8 +423,8 @@ namespace tensor_lib
         friend class subdimension<T, Rank>;
         friend class tensor<T, Rank>;
 
-        using iterator = _tensor_common<T>::iterator;
-        using const_iterator = _tensor_common<T>::const_iterator;
+        using iterator = typename _tensor_common<T>::iterator;
+        using const_iterator = typename _tensor_common<T>::const_iterator;
 
         constexpr const_subdimension() = delete;
         constexpr const_subdimension(const_subdimension&&) noexcept = delete;
@@ -570,10 +572,8 @@ namespace tensor_lib
         friend class subdimension<T, Rank + 1>;
         friend class tensor<T, useful_specializations::no_zero(Rank - 1)>;
 
-        
-
-        using iterator = _tensor_common<T>::iterator;
-        using const_iterator = _tensor_common<T>::const_iterator;
+        using iterator = typename _tensor_common<T>::iterator;
+        using const_iterator = typename _tensor_common<T>::const_iterator;
 
         constexpr subdimension() = delete;
         constexpr subdimension(subdimension&&) noexcept = delete;
@@ -759,9 +759,9 @@ namespace tensor_lib
             return reinterpret_cast<T*>(&it);
         }
 
-        template <typename TT, typename U, std::size_t Rank>
+        template <typename TT, typename U, std::size_t RankS>
             requires std::convertible_to<TT, U> && std::convertible_to<U, TT>
-        friend constexpr void swap (subdimension<TT, Rank>&& left, subdimension<U, Rank>&& right);
+        friend constexpr void swap (subdimension<TT, RankS>&& left, subdimension<U, RankS>&& right);
     };
 
     template <typename T>

--- a/tensor_const_testing_suit.hpp
+++ b/tensor_const_testing_suit.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <iostream>
 #include "tensor.hpp"
+
+#include <iostream>
 
 namespace tensor_const_testing_suit
 {

--- a/tensor_initialization_testing_suit.hpp
+++ b/tensor_initialization_testing_suit.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include <iostream>
-#include <algorithm>
 #include "helpers.hpp"
 #include "tensor.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
 
 namespace tensor_initialization_testing_suit
 {

--- a/tensor_iteration_testing_suit.hpp
+++ b/tensor_iteration_testing_suit.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <iostream>
-#include <algorithm>
-#include <array>
 #include "helpers.hpp"
 #include "tensor.hpp"
+
+#include <algorithm>
+#include <array>
+#include <iostream>
 
 namespace tensor_iteration_testing_suit
 {

--- a/tensor_move_semantics_testing_suit.hpp
+++ b/tensor_move_semantics_testing_suit.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <iostream>
-#include <algorithm>
 #include "helpers.hpp"
 #include "tensor.hpp"
+
+#include <algorithm>
+#include <iostream>
 
 namespace tensor_move_semantics_testing_suit
 {

--- a/tensor_resize_testing_suit.hpp
+++ b/tensor_resize_testing_suit.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include <iostream>
-#include <algorithm>
 #include "helpers.hpp"
 #include "tensor.hpp"
+
+#include <algorithm>
+#include <iostream>
 
 namespace tensor_resize_testing_suit
 {

--- a/tensor_testing_suit.hpp
+++ b/tensor_testing_suit.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <iostream>
 #include "tensor.hpp"
 #include "tensor_const_testing_suit.hpp"
 #include "tensor_initialization_testing_suit.hpp"
 #include "tensor_move_semantics_testing_suit.hpp"
 #include "tensor_resize_testing_suit.hpp"
 #include "tensor_iteration_testing_suit.hpp"
+
+#include <iostream>
 
 namespace tensor_testing_suit
 {

--- a/useful_concepts.hpp
+++ b/useful_concepts.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <type_traits>
 #include <concepts>
 #include <iostream>
+#include <type_traits>
 
 namespace useful_concepts
 {
@@ -81,8 +81,8 @@ namespace useful_concepts
         divisible_with<T, U> &&
         divisible_with<U, T>;
 
-    template <typename... T, size_t SUM>
-    concept size_of_parameter_pack_equals = requires ()
+    template <size_t SUM, typename... T>
+    concept size_of_parameter_pack_equals = requires()
     {
         requires(sizeof...(T) == SUM);
     };

--- a/useful_specializations.hpp
+++ b/useful_specializations.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "useful_concepts.hpp"
+
 #include <type_traits>
 #include <initializer_list>
-#include "useful_concepts.hpp"
 
 namespace useful_specializations
 {


### PR DESCRIPTION
I also added CMake support and ctest, the test are run automatically with a GitHub action you will see that here: https://github.com/cristi1990an/Tensor-plus-plus/actions once merged

there is a lot of warnings you should see (the GitHub action is compiling it with warnings treated as errors: `-Werror`)

I reorganized your includes, you should put standard library headers at the end to avoid not seeing missing include problems

You should add a `.clang-format` https://clang.llvm.org/docs/ClangFormat.html to have a consistent style, I saw you use spaces and tabs you should not mix them