### PR TITLE
Added tensor::replace() and subdimension::replace() methods 

### DIFF
--- a/Tensor++.vcxproj
+++ b/Tensor++.vcxproj
@@ -173,6 +173,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="all_test.cpp" />
     <ClCompile Include="introduction.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Tensor++.vcxproj
+++ b/Tensor++.vcxproj
@@ -173,7 +173,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="all_test.cpp" />
     <ClCompile Include="introduction.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -184,6 +183,7 @@
     <ClInclude Include="tensor_initialization_testing_suit.hpp" />
     <ClInclude Include="tensor_iteration_testing_suit.hpp" />
     <ClInclude Include="tensor_move_semantics_testing_suit.hpp" />
+    <ClInclude Include="tensor_replace_testing_suit.hpp" />
     <ClInclude Include="tensor_resize_testing_suit.hpp" />
     <ClInclude Include="tensor_testing_suit.hpp" />
     <ClInclude Include="useful_concepts.hpp" />

--- a/Tensor++.vcxproj.filters
+++ b/Tensor++.vcxproj.filters
@@ -18,6 +18,9 @@
     <ClCompile Include="introduction.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="all_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="helpers.hpp">

--- a/Tensor++.vcxproj.filters
+++ b/Tensor++.vcxproj.filters
@@ -18,9 +18,6 @@
     <ClCompile Include="introduction.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="all_test.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="helpers.hpp">
@@ -54,6 +51,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="tensor_iteration_testing_suit.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="tensor_replace_testing_suit.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/all_test.cpp
+++ b/all_test.cpp
@@ -1,6 +1,6 @@
-#include "tensor_testing_suit.hpp"
-
-int main()
-{
-	tensor_testing_suit::RUN_ALL_TESTS();
-}
+//#include "tensor_testing_suit.hpp"
+//
+//int main()
+//{
+//	tensor_testing_suit::RUN_ALL_TESTS();
+//}

--- a/all_test.cpp
+++ b/all_test.cpp
@@ -1,6 +1,6 @@
-//#include "tensor_testing_suit.hpp"
-//
-//int main()
-//{
-//	tensor_testing_suit::RUN_ALL_TESTS();
-//}
+#include "tensor_testing_suit.hpp"
+
+int main()
+{
+	tensor_testing_suit::RUN_ALL_TESTS();
+}

--- a/introduction.cpp
+++ b/introduction.cpp
@@ -205,5 +205,5 @@ int main()
 
 
 	tensor_testing_suit::RUN_ALL_TESTS();
-	// benchmark::RUN_ALL();
+	benchmark::RUN_ALL();
 }

--- a/introduction.cpp
+++ b/introduction.cpp
@@ -78,7 +78,7 @@ int main()
 		Another feature tensor implements is being able to stack calls of the '[]' operator relative to each dimension.
 		Here we have a tensor with 3 dimension. Each of these dimensions has 4 subdimensions. Each of these subdimension has 5 sub-subdimensions and so on...
 	*/
-	tensor<int, 5> my_tensor(3, 4, 5, 6, 7); // Explicitly creating a 5-dimensional tensor of sizes 3 by 4 by 5 by 6 by 7
+	tensor<int, 5> my_tensor(3, 4, 5, 2, 2); // Explicitly creating a 5-dimensional tensor of sizes 3 by 4 by 5 by 2 by 2
 
 	int val = 0;
 
@@ -97,6 +97,34 @@ int main()
 			}
 		}
 	}
+
+	/*
+		tensor_lib::tensor also supports a number of ways to manipulate subdimensions. For example, we can easily delimit a subdimension, no matter the rank, and change its value
+		explicitly to something else. In the case below, we delimitate the first of the "deepest" 2x2 subdimensions in our 'my_tensor' variable and change their value to something else.
+
+		We can do this through a nested initializer_list that reflects its structure:
+	*/
+
+	my_tensor[0][0][0] =
+	{
+		{ 1, 2 },
+		{ 3, 4 }
+	};
+
+	/*
+		A simple initializer_list if we only want to focus on the values themselves:
+	*/
+
+	my_tensor[0][0][0] = { 1, 2, 3, 4 };
+
+	/*
+		Through iterators:
+	*/
+
+	int aux = 1;
+
+	for (auto& val : my_tensor[0][0][0])
+		val = aux++;
 
 	/*
 		Template parameters
@@ -120,16 +148,8 @@ int main()
 		subdimension. On the bright side, we're providing standard iteration capabilities, not only through the whole tensor, but through each subdimension at any of the ranks.
 		A tensor's memory is contiguous in memory and we can take advantage of far greater performance when iterating through our data this way. Preferably, users can
 		use the square paranthesis operator to calculate the value range representing their desired subdimension and then access its value like a normal array.
-		In the example below we're iterating through the whole first subdimension of the second rank of the tensor, setting each value to zero.
-	*/
 
-	for (auto& vals : my_tensor[0][0])
-	{
-		vals = 0;
-	}
-
-	/*
-		Tensor is also compatible with standard algorithms.
+		Tensor is also compatible with standard algorithms:
 	*/
 
 	std::fill(my_tensor[2][1].begin(), my_tensor[2][1].end(), 0);
@@ -185,5 +205,5 @@ int main()
 
 
 	tensor_testing_suit::RUN_ALL_TESTS();
-	benchmark::RUN_ALL();
+	// benchmark::RUN_ALL();
 }

--- a/tensor.hpp
+++ b/tensor.hpp
@@ -277,6 +277,20 @@ namespace tensor_lib
 			return *this;
 		}
 
+		constexpr auto& replace(const const_subdimension<T, Rank>& other) TENSORLIB_NOEXCEPT_IN_RELEASE
+		{
+			if constexpr (TENSORLIB_DEBUGGING)
+				if (!std::equal(this->_order_of_dimension.begin(), this->_order_of_dimension.end(), other._order_of_dimension.begin()))
+					throw std::runtime_error("Size of tensor we take values from must match the size of current tensor");
+
+			for (std::size_t i = 0; i < size_of_current_tensor(); i++)
+			{
+				_data[i] = other._data[i];
+			}
+
+			return *this;
+		}
+
 		constexpr auto& operator=(const useful_specializations::nested_initializer_list<T, Rank>& data) TENSORLIB_NOEXCEPT_IN_RELEASE
 			requires useful_concepts::is_greater_than<size_t, size_t, Rank, 2>
 		{
@@ -668,6 +682,20 @@ namespace tensor_lib
 		}
 
 		constexpr auto& replace(const subdimension<T, Rank>& other) TENSORLIB_NOEXCEPT_IN_RELEASE
+		{
+			if constexpr (TENSORLIB_DEBUGGING)
+				if (!std::equal(this->_order_of_dimension.begin(), this->_order_of_dimension.end(), other._order_of_dimension.begin()))
+					throw std::runtime_error("Size of tensor we take values from must match the size of current tensor");
+
+			for (std::size_t i = 0; i < size_of_current_tensor(); i++)
+			{
+				_data[i] = other._data[i];
+			}
+
+			return *this;
+		}
+
+		constexpr auto& replace(const const_subdimension<T, Rank>& other) TENSORLIB_NOEXCEPT_IN_RELEASE
 		{
 			if constexpr (TENSORLIB_DEBUGGING)
 				if (!std::equal(this->_order_of_dimension.begin(), this->_order_of_dimension.end(), other._order_of_dimension.begin()))

--- a/tensor.hpp
+++ b/tensor.hpp
@@ -47,7 +47,7 @@ namespace tensor_lib
 
 	template <typename T, size_t Rank>
 	requires useful_concepts::is_not_zero<size_t, Rank>
-		class tensor : private _tensor_common<T>
+		class tensor : public _tensor_common<T>
 	{
 	private:
 		// Stores the size of each individual dimension of the tensor.
@@ -249,6 +249,34 @@ namespace tensor_lib
 			return *this;
 		}
 
+		constexpr auto& replace(const tensor& other) TENSORLIB_NOEXCEPT_IN_RELEASE
+		{
+			if constexpr (TENSORLIB_DEBUGGING)
+				if (!std::equal(this->_order_of_dimension.begin(), this->_order_of_dimension.end(), other._order_of_dimension.begin()))
+					throw std::runtime_error("Size of tensor we take values from must match the size of current tensor");
+
+			for (std::size_t i = 0; i < size_of_current_tensor(); i++)
+			{
+				_data[i] = other._data[i];
+			}
+
+			return *this;
+		}
+
+		constexpr auto& replace(const subdimension<T, Rank>& other) TENSORLIB_NOEXCEPT_IN_RELEASE
+		{
+			if constexpr (TENSORLIB_DEBUGGING)
+				if (!std::equal(this->_order_of_dimension.begin(), this->_order_of_dimension.end(), other._order_of_dimension.begin()))
+					throw std::runtime_error("Size of tensor we take values from must match the size of current tensor");
+
+			for (std::size_t i = 0; i < size_of_current_tensor(); i++)
+			{
+				_data[i] = other._data[i];
+			}
+
+			return *this;
+		}
+
 		constexpr auto& operator=(const useful_specializations::nested_initializer_list<T, Rank>& data) TENSORLIB_NOEXCEPT_IN_RELEASE
 			requires useful_concepts::is_greater_than<size_t, size_t, Rank, 2>
 		{
@@ -414,7 +442,7 @@ namespace tensor_lib
 
 	template <typename T, size_t Rank>
 	requires useful_concepts::is_not_zero<size_t, Rank>
-		class const_subdimension : private _tensor_common<T>
+		class const_subdimension : public _tensor_common<T>
 	{
 		using ConstSourceSizeOfDimensionArraySpan = std::span<const size_t, Rank>;
 		using ConstSourceSizeOfSubdimensionArraySpan = std::span<const size_t, Rank>;
@@ -564,7 +592,7 @@ namespace tensor_lib
 
 	template <typename T, std::size_t Rank>
 	requires useful_concepts::is_not_zero<size_t, Rank>
-		class subdimension : private _tensor_common<T>
+		class subdimension : public _tensor_common<T>
 	{
 		using SourceSizeOfDimensionArraySpan = std::span<size_t, Rank>;
 		using SourceSizeOfSubdimensionArraySpan = std::span<size_t, Rank>;
@@ -621,6 +649,34 @@ namespace tensor_lib
 			_order_of_dimension = other._order_of_dimension;
 			_size_of_subdimension = other._size_of_subdimension;
 			_data = other._data;
+
+			return *this;
+		}
+
+		constexpr auto& replace(const tensor<T, Rank>& other) TENSORLIB_NOEXCEPT_IN_RELEASE
+		{
+			if constexpr (TENSORLIB_DEBUGGING)
+				if (!std::equal(this->_order_of_dimension.begin(), this->_order_of_dimension.end(), other._order_of_dimension.begin()))
+					throw std::runtime_error("Size of tensor we take values from must match the size of current tensor");
+
+			for (std::size_t i = 0; i < size_of_current_tensor(); i++)
+			{
+				_data[i] = other._data[i];
+			}
+
+			return *this;
+		}
+
+		constexpr auto& replace(const subdimension<T, Rank>& other) TENSORLIB_NOEXCEPT_IN_RELEASE
+		{
+			if constexpr (TENSORLIB_DEBUGGING)
+				if (!std::equal(this->_order_of_dimension.begin(), this->_order_of_dimension.end(), other._order_of_dimension.begin()))
+					throw std::runtime_error("Size of tensor we take values from must match the size of current tensor");
+
+			for (std::size_t i = 0; i < size_of_current_tensor(); i++)
+			{
+				_data[i] = other._data[i];
+			}
 
 			return *this;
 		}
@@ -1061,17 +1117,33 @@ namespace tensor_lib
 			if (!std::equal(left._order_of_dimension.begin(), left._order_of_dimension.end(), right._order_of_dimension.begin()))
 				throw std::runtime_error("Can't swap subdimensions of different sizes!");
 
+		if constexpr (std::is_same_v<T, U> == true)
+			if (std::addressof(left) == std::addressof(right))
+				return;
+
 		const auto size = left.size_of_current_tensor();
 
 		std::unique_ptr<T[]> aux(new T[size]);
 
 		std::memcpy(aux.get(), left._data.data(), sizeof(T) * size);
 
-		std::transform(right._data.begin(), right._data.end(), left._data.begin(), [](const U& val) { return static_cast<T>(val); });
-
-		for (std::size_t i = 0; i < size; i++)
+		if constexpr (std::is_same_v<T, U> != true)
 		{
-			right._data.data()[i] = static_cast<U>(aux[i]);
+			std::transform(right._data.begin(), right._data.end(), left._data.begin(), [](const U& val) { return static_cast<T>(val); });
+
+			for (std::size_t i = 0; i < size; i++)
+			{
+				right._data.data()[i] = static_cast<U>(aux[i]);
+			}
+		}
+		else
+		{
+			std::copy(right._data.begin(), right._data.end(), left._data.begin());
+
+			for (std::size_t i = 0; i < size; i++)
+			{
+				right._data.data()[i] = aux[i];
+			}
 		}
 	}
 

--- a/tensor_replace_testing_suit.hpp
+++ b/tensor_replace_testing_suit.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+#include "helpers.hpp"
+#include "tensor.hpp"
+
+#include <algorithm>
+#include <iostream>
+#include <array>
+
+namespace tensor_replace_testing_suit
+{
+	using namespace tensor_lib;
+
+	void TEST_1()
+	{
+		tensor<int, 3> tsor(3, 2, 2);
+		tensor<int, 3> result(3, 2, 2);
+		std::array<int, 3 * 2 * 2> expected;
+
+		int aux = 1;
+		for (auto& val : tsor)
+		{
+			val = aux++;
+		}
+
+		aux = 1;
+		for (auto& val : expected)
+		{
+			val = aux++;
+		}
+
+		std::fill(result.begin(), result.end(), 0);
+
+		result.replace(tsor);
+
+		if(!std::equal(tsor.cbegin(), tsor.cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_1 in 'tensor_replace_testing_suit' failed!\n");
+
+		if (!std::equal(result.cbegin(), result.cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_1 in 'tensor_replace_testing_suit' failed!\n");
+
+		std::cout << "\tTEST 1 PASSED.\n";
+	}
+
+	void TEST_2()
+	{
+		tensor<int, 3> tsor(3, 2, 2);
+		tensor<int, 2> result(2, 2);
+		std::array<int, 2 * 2> expected;
+
+		int aux = 1;
+		for (auto& val : tsor)
+		{
+			val = aux++;
+		}
+
+		aux = 1;
+		for (auto& val : expected)
+		{
+			val = aux++;
+		}
+
+		std::fill(result.begin(), result.end(), 0);
+
+		result.replace(tsor[0]);
+
+		if (!std::equal(tsor[0].cbegin(), tsor[0].cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_2 in 'tensor_replace_testing_suit' failed!\n");
+
+		if (!std::equal(result.cbegin(), result.cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_2 in 'tensor_replace_testing_suit' failed!\n");
+
+		std::cout << "\tTEST 2 PASSED.\n";
+	}
+
+	void TEST_3()
+	{
+		tensor<int, 2> tsor(2, 2);
+		tensor<int, 3> result(3, 2, 2);
+		std::array<int, 2 * 2> expected;
+
+		int aux = 1;
+		for (auto& val : tsor)
+		{
+			val = aux++;
+		}
+
+		aux = 1;
+		for (auto& val : expected)
+		{
+			val = aux++;
+		}
+
+		std::fill(result.begin(), result.end(), 0);
+
+		result[0].replace(tsor);
+
+		if (!std::equal(tsor.cbegin(), tsor.cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_3 in 'tensor_replace_testing_suit' failed!\n");
+
+		if (!std::equal(result[0].cbegin(), result[0].cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_3 in 'tensor_replace_testing_suit' failed!\n");
+
+		std::cout << "\tTEST 3 PASSED.\n";
+	}
+
+	void TEST_4()
+	{
+		tensor<int, 3> tsor(3, 2, 2);
+		tensor<int, 3> result(3, 2, 2);
+		std::array<int, 2 * 2> expected;
+
+		int aux = 1;
+		for (auto& val : tsor)
+		{
+			val = aux++;
+		}
+
+		aux = 1;
+		for (auto& val : expected)
+		{
+			val = aux++;
+		}
+
+		std::fill(result.begin(), result.end(), 0);
+
+		result[0].replace(tsor[0]);
+
+		if (!std::equal(tsor[0].cbegin(), tsor[0].cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_4 in 'tensor_replace_testing_suit' failed!\n");
+
+		if (!std::equal(result[0].cbegin(), result[0].cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_4 in 'tensor_replace_testing_suit' failed!\n");
+
+		std::cout << "\tTEST 4 PASSED.\n";
+	}
+
+	void RUN_ALL()
+	{
+		std::cout << "Running tensor replace tests...\n\n";
+
+		TEST_1();
+		TEST_2();
+		TEST_3();
+		TEST_4();
+
+		std::cout << "\n";
+	}
+}

--- a/tensor_replace_testing_suit.hpp
+++ b/tensor_replace_testing_suit.hpp
@@ -135,6 +135,71 @@ namespace tensor_replace_testing_suit
 		std::cout << "\tTEST 4 PASSED.\n";
 	}
 
+	void TEST_5()
+	{
+		tensor<int, 3> tsor(3, 2, 2);
+		const_subdimension<int, 3> source(tsor);
+		tensor<int, 3> result(3, 2, 2);
+		std::array<int, 3 * 2 * 2> expected;
+
+		int aux = 1;
+		for (auto& val : tsor)
+		{
+			val = aux++;
+		}
+
+		aux = 1;
+		for (auto& val : expected)
+		{
+			val = aux++;
+		}
+
+		std::fill(result.begin(), result.end(), 0);
+
+		result.replace(source);
+
+		if (!std::equal(tsor.cbegin(), tsor.cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_5 in 'tensor_replace_testing_suit' failed!\n");
+
+		if (!std::equal(result.cbegin(), result.cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_5 in 'tensor_replace_testing_suit' failed!\n");
+
+		std::cout << "\tTEST 5 PASSED.\n";
+	}
+
+	void TEST_6()
+	{
+		tensor<int, 3> tsor(3, 2, 2);
+		const_subdimension<int, 3> source(tsor);
+		tensor<int, 3> result(3, 2, 2);
+		subdimension<int, 3> destination(result);
+		std::array<int, 3 * 2 * 2> expected;
+
+		int aux = 1;
+		for (auto& val : tsor)
+		{
+			val = aux++;
+		}
+
+		aux = 1;
+		for (auto& val : expected)
+		{
+			val = aux++;
+		}
+
+		std::fill(result.begin(), result.end(), 0);
+
+		destination.replace(source);
+
+		if (!std::equal(tsor.cbegin(), tsor.cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_6 in 'tensor_replace_testing_suit' failed!\n");
+
+		if (!std::equal(result.cbegin(), result.cend(), expected.cbegin()))
+			throw std::runtime_error("TEST_6 in 'tensor_replace_testing_suit' failed!\n");
+
+		std::cout << "\tTEST 6 PASSED.\n";
+	}
+
 	void RUN_ALL()
 	{
 		std::cout << "Running tensor replace tests...\n\n";
@@ -143,6 +208,8 @@ namespace tensor_replace_testing_suit
 		TEST_2();
 		TEST_3();
 		TEST_4();
+		TEST_5();
+		TEST_6();
 
 		std::cout << "\n";
 	}

--- a/tensor_testing_suit.hpp
+++ b/tensor_testing_suit.hpp
@@ -6,6 +6,7 @@
 #include "tensor_move_semantics_testing_suit.hpp"
 #include "tensor_resize_testing_suit.hpp"
 #include "tensor_iteration_testing_suit.hpp"
+#include "tensor_replace_testing_suit.hpp"
 
 #include <iostream>
 
@@ -18,6 +19,7 @@ namespace tensor_testing_suit
 		tensor_initialization_testing_suit::RUN_ALL();
 		tensor_const_testing_suit::RUN_ALL();
 		tensor_move_semantics_testing_suit::RUN_ALL();
+		tensor_replace_testing_suit::RUN_ALL();
 		tensor_resize_testing_suit::RUN_ALL();
 		tensor_iteration_testing_suit::RUN_ALL();
 	}


### PR DESCRIPTION
replace() is supposed to be a size-checking copy assignment operator. The copy assignment operator for subdimension is currently working the same way an iterator would, making the object "point" to a different subdimension, maybe even in a different tensor. replace() does a size check and copies the values from the tensor/subdimension/const_subdimension reference it was given, without modifying it. replace() was also added to the tensor class for continuity and it differs from the copy assignment operator by not allowing resizes, the source of the data must have the same order as the destination. 